### PR TITLE
Fix image preview toggle behavior in ddu-ui-filer

### DIFF
--- a/dot_config/nvim/lua/plugins/ddu-ui-filer.lua
+++ b/dot_config/nvim/lua/plugins/ddu-ui-filer.lua
@@ -70,6 +70,10 @@ local function clear_image()
 end
 
 local function preview_image(path)
+  -- Close existing preview first to avoid toggle behavior
+  clear_image()
+  vim.fn["ddu#ui#do_action"]("closePreviewWindow")
+
   local filer_win = vim.api.nvim_get_current_win()
   local wins_before = {}
   for _, win in ipairs(vim.api.nvim_list_wins()) do
@@ -120,6 +124,7 @@ vim.api.nvim_create_autocmd("FileType", {
     vim.keymap.set("n", "p", function()
       local item = vim.fn["ddu#ui#get_item"]()
       if not item or item.isTree then
+        clear_image()
         vim.fn["ddu#ui#do_action"]("preview")
         return
       end
@@ -128,6 +133,7 @@ vim.api.nvim_create_autocmd("FileType", {
       if is_image_file(path) then
         preview_image(path)
       else
+        clear_image()
         vim.fn["ddu#ui#do_action"]("preview")
       end
     end, opts)


### PR DESCRIPTION
## Summary
This PR fixes the image preview behavior in the ddu-ui-filer plugin to prevent unintended toggle behavior when previewing images.

## Key Changes
- **Clear existing preview before opening new one**: Added `clear_image()` and `closePreviewWindow` calls at the start of `preview_image()` to ensure any existing preview is closed before displaying a new one
- **Clear preview when navigating to directories**: Added `clear_image()` call when previewing tree items (directories) to properly clean up image previews
- **Clear preview for non-image files**: Added `clear_image()` call when previewing non-image files to ensure image previews don't persist when switching file types

## Implementation Details
The changes ensure that:
1. Image previews are properly closed before opening new ones, preventing the preview from toggling on/off when the same image is selected
2. Switching between different file types (images, non-images, directories) properly clears previous image previews
3. The preview window state is consistently managed across different preview scenarios

https://claude.ai/code/session_011t1eHiZv3XpQYm4cPDQ3ay