### PR TITLE
feat: add Japanese Wiktionary lookup to Neovim

### DIFF
--- a/dot_config/nvim/lua/config/commands/wiktionary.lua
+++ b/dot_config/nvim/lua/config/commands/wiktionary.lua
@@ -2,7 +2,7 @@ local wiktionary = require("wiktionary")
 
 vim.api.nvim_create_user_command("Wiktionary", function(options)
   if options.range > 0 then
-    wiktionary.lookup_visual()
+    wiktionary.lookup_visual(options.line1, options.line2)
   else
     wiktionary.lookup()
   end

--- a/dot_config/nvim/lua/config/commands/wiktionary.lua
+++ b/dot_config/nvim/lua/config/commands/wiktionary.lua
@@ -1,8 +1,19 @@
 local wiktionary = require("wiktionary")
 
+local function is_visual_range(options)
+  local start_position = vim.fn.getpos("'<")
+  local end_position = vim.fn.getpos("'>")
+
+  return vim.fn.visualmode() ~= "" and options.line1 == start_position[2] and options.line2 == end_position[2]
+end
+
 vim.api.nvim_create_user_command("Wiktionary", function(options)
   if options.range > 0 then
-    wiktionary.lookup_visual(options.line1, options.line2)
+    if is_visual_range(options) then
+      wiktionary.lookup_visual()
+    else
+      wiktionary.lookup_visual(options.line1, options.line2)
+    end
   else
     wiktionary.lookup()
   end

--- a/dot_config/nvim/lua/config/commands/wiktionary.lua
+++ b/dot_config/nvim/lua/config/commands/wiktionary.lua
@@ -1,0 +1,12 @@
+local wiktionary = require("wiktionary")
+
+vim.api.nvim_create_user_command("Wiktionary", function(options)
+  if options.range > 0 then
+    wiktionary.lookup_visual()
+  else
+    wiktionary.lookup()
+  end
+end, {
+  desc = "Look up a Japanese term in Wiktionary",
+  range = true,
+})

--- a/dot_config/nvim/lua/config/utils.lua
+++ b/dot_config/nvim/lua/config/utils.lua
@@ -167,6 +167,11 @@ M.get_visual_query_text = function()
   return normalize_query_text(text)
 end
 
+M.get_range_query_text = function(start_line, end_line)
+  local lines = vim.api.nvim_buf_get_lines(0, start_line - 1, end_line, false)
+  return normalize_query_text(table.concat(lines, "\n"))
+end
+
 M.url_encode = function(value)
   return (value:gsub("([^%w%-_%.~])", function(char)
     return string.format("%%%02X", string.byte(char))

--- a/dot_config/nvim/lua/config/utils.lua
+++ b/dot_config/nvim/lua/config/utils.lua
@@ -1,5 +1,25 @@
 local M = {}
 
+local function is_visual_mode(mode)
+  return mode == "v" or mode == "V" or mode == "\22"
+end
+
+local function get_visual_region()
+  local mode = vim.fn.mode()
+  local active = is_visual_mode(mode)
+  local start_pos = vim.fn.getpos(active and "v" or "'<")
+  local end_pos = vim.fn.getpos(active and "." or "'>")
+
+  if start_pos[2] == 0 or end_pos[2] == 0 then
+    return {}
+  end
+
+  return vim.fn.getregion(start_pos, end_pos, {
+    exclusive = false,
+    type = active and mode or vim.fn.visualmode(),
+  })
+end
+
 local function get_visual_selection()
   local start_pos = vim.fn.getpos("'<")
   local end_pos = vim.fn.getpos("'>")
@@ -15,6 +35,10 @@ local function get_visual_selection()
 end
 
 local function get_visual_text_internal(options)
+  if options.block_mode == "strict" then
+    return table.concat(get_visual_region(), "\n")
+  end
+
   local selection = get_visual_selection()
   local start_pos = selection.start_pos
   local end_pos = selection.end_pos
@@ -22,14 +46,6 @@ local function get_visual_text_internal(options)
 
   if #lines == 0 then
     return ""
-  end
-
-  if options.block_mode == "strict" then
-    local region = vim.fn.getregion(start_pos, end_pos, {
-      exclusive = false,
-      type = vim.fn.visualmode(),
-    })
-    return table.concat(region, "\n")
   end
 
   local start_col_index = start_pos[3] - 1

--- a/dot_config/nvim/lua/wiktionary/api.lua
+++ b/dot_config/nvim/lua/wiktionary/api.lua
@@ -8,6 +8,8 @@ local function build_arguments(user_agent, parameters)
     "--fail",
     "--get",
     "--location",
+    "--max-time",
+    "10",
     "--silent",
     "--show-error",
     "--header",

--- a/dot_config/nvim/lua/wiktionary/api.lua
+++ b/dot_config/nvim/lua/wiktionary/api.lua
@@ -32,40 +32,51 @@ function M.new(options)
   local user_agent = options.user_agent
 
   local function request(parameters, transform, callback)
+    local finished = false
+
+    local function complete(result, err)
+      if finished then
+        return
+      end
+
+      finished = true
+      callback(result, err)
+    end
+
     if executable("curl") ~= 1 then
       schedule(function()
-        callback(nil, { kind = "curl_missing" })
+        complete(nil, { kind = "curl_missing" })
       end)
       return
     end
 
-    local started = pcall(system, build_arguments(user_agent, parameters), { text = true }, function(completed)
+    local started = pcall(system, build_arguments(user_agent, parameters), { text = true }, function(process_result)
       schedule(function()
-        if completed.code ~= 0 then
-          callback(nil, { kind = completed.code == 22 and "api" or "network" })
+        if process_result.code ~= 0 then
+          complete(nil, { kind = process_result.code == 22 and "api" or "network" })
           return
         end
 
-        local decoded, payload = pcall(vim.json.decode, completed.stdout or "")
+        local decoded, payload = pcall(vim.json.decode, process_result.stdout or "")
         if not decoded or type(payload) ~= "table" then
-          callback(nil, { kind = "json" })
+          complete(nil, { kind = "json" })
           return
         end
 
         if type(payload.error) == "table" then
           local kind = payload.error.code == "missingtitle" and "not_found" or "api"
-          callback(nil, { kind = kind })
+          complete(nil, { kind = kind })
           return
         end
 
         local result, transform_error = transform(payload)
-        callback(result, transform_error)
+        complete(result, transform_error)
       end)
     end)
 
     if not started then
       schedule(function()
-        callback(nil, { kind = "network" })
+        complete(nil, { kind = "network" })
       end)
     end
   end
@@ -110,7 +121,11 @@ function M.new(options)
 
       local titles = {}
       for _, item in ipairs(payload.query.search) do
-        if type(item.title) == "string" and item.title ~= "" then
+        if type(item) ~= "table" or type(item.title) ~= "string" then
+          return nil, { kind = "api" }
+        end
+
+        if item.title ~= "" then
           table.insert(titles, item.title)
         end
       end

--- a/dot_config/nvim/lua/wiktionary/api.lua
+++ b/dot_config/nvim/lua/wiktionary/api.lua
@@ -1,0 +1,128 @@
+local M = {}
+
+local endpoint = "https://ja.wiktionary.org/w/api.php"
+
+local function build_arguments(user_agent, parameters)
+  local arguments = {
+    "curl",
+    "--fail",
+    "--get",
+    "--location",
+    "--silent",
+    "--show-error",
+    "--header",
+    "Accept: application/json",
+    "--user-agent",
+    user_agent,
+  }
+
+  for _, parameter in ipairs(parameters) do
+    table.insert(arguments, "--data-urlencode")
+    table.insert(arguments, parameter)
+  end
+
+  table.insert(arguments, endpoint)
+  return arguments
+end
+
+function M.new(options)
+  local executable = options.executable or vim.fn.executable
+  local schedule = options.schedule or vim.schedule
+  local system = options.system or vim.system
+  local user_agent = options.user_agent
+
+  local function request(parameters, transform, callback)
+    if executable("curl") ~= 1 then
+      schedule(function()
+        callback(nil, { kind = "curl_missing" })
+      end)
+      return
+    end
+
+    local started = pcall(system, build_arguments(user_agent, parameters), { text = true }, function(completed)
+      schedule(function()
+        if completed.code ~= 0 then
+          callback(nil, { kind = completed.code == 22 and "api" or "network" })
+          return
+        end
+
+        local decoded, payload = pcall(vim.json.decode, completed.stdout or "")
+        if not decoded or type(payload) ~= "table" then
+          callback(nil, { kind = "json" })
+          return
+        end
+
+        if type(payload.error) == "table" then
+          local kind = payload.error.code == "missingtitle" and "not_found" or "api"
+          callback(nil, { kind = kind })
+          return
+        end
+
+        local result, transform_error = transform(payload)
+        callback(result, transform_error)
+      end)
+    end)
+
+    if not started then
+      schedule(function()
+        callback(nil, { kind = "network" })
+      end)
+    end
+  end
+
+  local function parse(title, callback)
+    request({
+      "action=parse",
+      "page=" .. title,
+      "prop=text|sections",
+      "format=json",
+      "formatversion=2",
+      "redirects=1",
+    }, function(payload)
+      if type(payload.parse) ~= "table"
+        or type(payload.parse.title) ~= "string"
+        or type(payload.parse.text) ~= "string"
+      then
+        return nil, { kind = "api" }
+      end
+
+      return {
+        html = payload.parse.text,
+        sections = type(payload.parse.sections) == "table" and payload.parse.sections or {},
+        title = payload.parse.title,
+      }, nil
+    end, callback)
+  end
+
+  local function search(term, limit, callback)
+    request({
+      "action=query",
+      "list=search",
+      "srsearch=" .. term,
+      "srnamespace=0",
+      "srlimit=" .. tostring(limit),
+      "format=json",
+      "formatversion=2",
+    }, function(payload)
+      if type(payload.query) ~= "table" or type(payload.query.search) ~= "table" then
+        return nil, { kind = "api" }
+      end
+
+      local titles = {}
+      for _, item in ipairs(payload.query.search) do
+        if type(item.title) == "string" and item.title ~= "" then
+          table.insert(titles, item.title)
+        end
+      end
+
+      return titles, nil
+    end, callback)
+  end
+
+  return {
+    parse = parse,
+    search = search,
+  }
+end
+
+return M

--- a/dot_config/nvim/lua/wiktionary/core.lua
+++ b/dot_config/nvim/lua/wiktionary/core.lua
@@ -1,0 +1,135 @@
+local M = {}
+
+local function normalize_query(query)
+  local normalized = tostring(query or ""):gsub("[\r\n]+", " ")
+  return vim.trim(normalized)
+end
+
+local function page_url(title)
+  return "https://ja.wiktionary.org/wiki/" .. vim.uri_encode(title, "rfc3986")
+end
+
+function M.new(dependencies)
+  local cache = {}
+  local pending = {}
+  local client = dependencies.client
+  local config = dependencies.config
+  local now = dependencies.now or os.time
+  local parser = dependencies.parser
+  local ui = dependencies.ui
+
+  local lookup_page
+  local search_candidates
+
+  local function finish(query)
+    pending[query] = nil
+  end
+
+  local function notify_error(err, query, title)
+    local messages = {
+      api = "Wiktionary APIでエラーが発生しました。",
+      curl_missing = "curlが見つかりません。",
+      json = "Wiktionary APIの応答を解析できませんでした。",
+      network = "Wiktionaryへの接続に失敗しました。",
+    }
+    local message = messages[err.kind]
+
+    if err.kind == "not_found" then
+      message = string.format('Wiktionaryに「%s」のページが見つかりませんでした。', query)
+    elseif err.kind == "missing_japanese" then
+      message = string.format('Wiktionaryの「%s」ページに日本語セクションがありません。', title)
+    elseif err.kind == "no_definitions" then
+      message = "語義を抽出できませんでした。\n" .. page_url(title)
+    elseif err.kind == "html_parse" then
+      message = "WiktionaryのHTMLを解析できませんでした。\n" .. page_url(title)
+    end
+
+    ui.notify(message or "Wiktionaryの検索に失敗しました。", vim.log.levels.ERROR)
+  end
+
+  local function handle_page(query, page)
+    local entries, extraction_error = parser.extract(page.html)
+    if extraction_error then
+      notify_error(extraction_error, query, page.title)
+      finish(query)
+      return
+    end
+
+    local result = {
+      entries = entries,
+      fetched_at = now(),
+      page_title = page.title,
+      query = query,
+    }
+    if config.cache then
+      cache[query] = result
+    end
+
+    ui.show(result, config)
+    finish(query)
+  end
+
+  search_candidates = function(query)
+    client.search(query, config.search_limit, function(candidates, search_error)
+      if search_error then
+        notify_error(search_error, query, query)
+        finish(query)
+        return
+      end
+
+      if #candidates == 0 then
+        notify_error({ kind = "not_found" }, query, query)
+        finish(query)
+        return
+      end
+
+      ui.select(candidates, query, function(choice)
+        if not choice then
+          finish(query)
+          return
+        end
+        lookup_page(query, choice, false)
+      end)
+    end)
+  end
+
+  lookup_page = function(query, title, search_when_missing)
+    client.parse(title, function(page, request_error)
+      if request_error then
+        if request_error.kind == "not_found" and search_when_missing then
+          search_candidates(query)
+        else
+          notify_error(request_error, query, title)
+          finish(query)
+        end
+        return
+      end
+
+      handle_page(query, page)
+    end)
+  end
+
+  local function lookup(raw_query)
+    local query = normalize_query(raw_query)
+    if query == "" then
+      ui.notify("検索語を取得できませんでした。", vim.log.levels.WARN)
+      return
+    end
+
+    if config.cache and cache[query] then
+      ui.show(cache[query], config)
+      return
+    end
+
+    if pending[query] then
+      return
+    end
+
+    pending[query] = true
+    lookup_page(query, query, true)
+  end
+
+  return { lookup = lookup }
+end
+
+return M

--- a/dot_config/nvim/lua/wiktionary/core.lua
+++ b/dot_config/nvim/lua/wiktionary/core.lua
@@ -116,12 +116,12 @@ function M.new(dependencies)
       return
     end
 
-    if config.cache and cache[query] then
-      ui.show(cache[query], config)
+    if pending[query] then
       return
     end
 
-    if pending[query] then
+    if config.cache and cache[query] then
+      ui.show(cache[query], config)
       return
     end
 

--- a/dot_config/nvim/lua/wiktionary/html.lua
+++ b/dot_config/nvim/lua/wiktionary/html.lua
@@ -85,8 +85,11 @@ local function append_text(tokens, value)
 end
 
 local function class_attribute(raw_tag)
-  return raw_tag:match('class%s*=%s*"([^"]*)"')
-    or raw_tag:match("class%s*=%s*'([^']*)'")
+  for attribute_name, _, value in raw_tag:gmatch([[%s+([%w:_-]+)%s*=%s*(["'])(.-)%2]]) do
+    if attribute_name == "class" then
+      return value
+    end
+  end
 end
 
 function M.tokenize(source)

--- a/dot_config/nvim/lua/wiktionary/html.lua
+++ b/dot_config/nvim/lua/wiktionary/html.lua
@@ -1,0 +1,149 @@
+local M = {}
+
+local named_entities = {
+  amp = "&",
+  apos = "'",
+  emsp = " ",
+  ensp = " ",
+  gt = ">",
+  hellip = "…",
+  laquo = "«",
+  lt = "<",
+  mdash = "—",
+  middot = "·",
+  nbsp = " ",
+  ndash = "–",
+  quot = '"',
+  raquo = "»",
+  thinsp = " ",
+}
+
+local void_tags = {
+  area = true,
+  base = true,
+  br = true,
+  col = true,
+  embed = true,
+  hr = true,
+  img = true,
+  input = true,
+  link = true,
+  meta = true,
+  param = true,
+  source = true,
+  track = true,
+  wbr = true,
+}
+
+local function decode_entity(entity)
+  if entity:sub(1, 1) ~= "#" then
+    return named_entities[entity] or "&" .. entity .. ";"
+  end
+
+  local number
+  if entity:sub(2, 2):lower() == "x" then
+    number = tonumber(entity:sub(3), 16)
+  else
+    number = tonumber(entity:sub(2), 10)
+  end
+
+  if not number or number < 0 or number > 0x10FFFF then
+    return "&" .. entity .. ";"
+  end
+
+  local ok, character = pcall(vim.fn.nr2char, number)
+  return ok and character or "&" .. entity .. ";"
+end
+
+local function decode_entities(text)
+  return (text:gsub("&([#xX%w]+);", decode_entity))
+end
+
+local function find_tag_end(source, start_index)
+  local quote = nil
+
+  for index = start_index, #source do
+    local character = source:sub(index, index)
+    if quote then
+      if character == quote then
+        quote = nil
+      end
+    elseif character == '"' or character == "'" then
+      quote = character
+    elseif character == ">" then
+      return index
+    end
+  end
+
+  return nil
+end
+
+local function append_text(tokens, value)
+  if value ~= "" then
+    table.insert(tokens, { kind = "text", value = decode_entities(value) })
+  end
+end
+
+local function class_attribute(raw_tag)
+  return raw_tag:match('class%s*=%s*"([^"]*)"')
+    or raw_tag:match("class%s*=%s*'([^']*)'")
+end
+
+function M.tokenize(source)
+  if type(source) ~= "string" then
+    return nil, "invalid_source"
+  end
+
+  local tokens = {}
+  local cursor = 1
+
+  while cursor <= #source do
+    local tag_start = source:find("<", cursor, true)
+    if not tag_start then
+      append_text(tokens, source:sub(cursor))
+      break
+    end
+
+    append_text(tokens, source:sub(cursor, tag_start - 1))
+
+    if source:sub(tag_start, tag_start + 3) == "<!--" then
+      local comment_end = source:find("-->", tag_start + 4, true)
+      if not comment_end then
+        return nil, "unterminated_comment"
+      end
+      cursor = comment_end + 3
+    else
+      local tag_end = find_tag_end(source, tag_start + 1)
+      if not tag_end then
+        return nil, "unterminated_tag"
+      end
+
+      local raw_tag = source:sub(tag_start + 1, tag_end - 1)
+      if not raw_tag:match("^%s*[!?]") then
+        local closing = raw_tag:match("^%s*/") ~= nil
+        local name = raw_tag:match("^%s*/?%s*([%w:_-]+)")
+        if not name then
+          return nil, "invalid_tag"
+        end
+
+        name = name:lower()
+        if closing then
+          table.insert(tokens, { kind = "end", name = name })
+        else
+          table.insert(tokens, {
+            class = class_attribute(raw_tag),
+            kind = "start",
+            name = name,
+            self_closing = void_tags[name] == true or raw_tag:match("/%s*$") ~= nil,
+          })
+        end
+      end
+
+      cursor = tag_end + 1
+    end
+  end
+
+  return tokens, nil
+end
+
+return M

--- a/dot_config/nvim/lua/wiktionary/init.lua
+++ b/dot_config/nvim/lua/wiktionary/init.lua
@@ -1,0 +1,50 @@
+local api = require("wiktionary.api")
+local core = require("wiktionary.core")
+local parser = require("wiktionary.parser")
+local ui = require("wiktionary.ui")
+local utils = require("config.utils")
+
+local M = {}
+
+local defaults = {
+  border = "rounded",
+  cache = true,
+  max_definitions = 5,
+  max_height = 30,
+  max_width = 80,
+  search_limit = 10,
+  user_agent = "nvim-wiktionary/0.1",
+}
+
+local config = vim.deepcopy(defaults)
+local engine = nil
+
+local function get_engine()
+  if not engine then
+    local client = api.new({ user_agent = config.user_agent })
+    engine = core.new({
+      client = client,
+      config = config,
+      parser = parser,
+      ui = ui,
+    })
+  end
+
+  return engine
+end
+
+function M.setup(options)
+  config = vim.tbl_deep_extend("force", vim.deepcopy(defaults), options or {})
+  engine = nil
+  return M
+end
+
+function M.lookup()
+  get_engine().lookup(vim.fn.expand("<cword>"))
+end
+
+function M.lookup_visual()
+  get_engine().lookup(utils.get_visual_query_text())
+end
+
+return M

--- a/dot_config/nvim/lua/wiktionary/init.lua
+++ b/dot_config/nvim/lua/wiktionary/init.lua
@@ -43,8 +43,9 @@ function M.lookup()
   get_engine().lookup(vim.fn.expand("<cword>"))
 end
 
-function M.lookup_visual()
-  get_engine().lookup(utils.get_visual_query_text())
+function M.lookup_visual(start_line, end_line)
+  local query = start_line and utils.get_range_query_text(start_line, end_line) or utils.get_visual_query_text()
+  get_engine().lookup(query)
 end
 
 return M

--- a/dot_config/nvim/lua/wiktionary/parser.lua
+++ b/dot_config/nvim/lua/wiktionary/parser.lua
@@ -1,0 +1,181 @@
+local html = require("wiktionary.html")
+
+local M = {}
+
+local supported_parts_of_speech = {
+  ["名詞"] = true,
+  ["動詞"] = true,
+  ["形容詞"] = true,
+  ["形容動詞"] = true,
+  ["副詞"] = true,
+  ["連体詞"] = true,
+  ["接続詞"] = true,
+  ["感動詞"] = true,
+  ["助詞"] = true,
+  ["助動詞"] = true,
+  ["接頭辞"] = true,
+  ["接尾辞"] = true,
+  ["成句"] = true,
+  ["慣用句"] = true,
+  ["ことわざ"] = true,
+}
+
+local ignored_tags = {
+  blockquote = true,
+  script = true,
+  style = true,
+  sup = true,
+  table = true,
+}
+
+local ignored_classes = {
+  ["mw-cite-backlink"] = true,
+  ["mw-editsection"] = true,
+  reference = true,
+  references = true,
+}
+
+local function has_ignored_class(class_attribute)
+  for class_name in (class_attribute or ""):gmatch("%S+") do
+    if ignored_classes[class_name] then
+      return true
+    end
+  end
+
+  return false
+end
+
+local function should_ignore(token)
+  return ignored_tags[token.name] == true or has_ignored_class(token.class)
+end
+
+local function clean_text(parts)
+  local text = table.concat(parts, " ")
+  text = text:gsub("​", "")
+  text = text:gsub("%s*%[%d+%]%s*", " ")
+  text = text:gsub("%s+", " ")
+  return vim.trim(text)
+end
+
+local function heading_level(name)
+  return tonumber(name:match("^h([2-6])$"))
+end
+
+function M.extract(source)
+  local tokens, token_error = html.tokenize(source)
+  if not tokens then
+    return nil, { kind = "html_parse", reason = token_error }
+  end
+
+  local entries = {}
+  local found_japanese = false
+  local in_japanese = false
+  local active_entry = nil
+  local heading = nil
+  local ignored_depth = 0
+  local ordered_depth = 0
+  local list_item_depth = 0
+  local definition_parts = nil
+
+  local function finish_heading()
+    local text = clean_text(heading.parts)
+    local level = heading.level
+    heading = nil
+
+    if level == 2 then
+      in_japanese = text == "日本語"
+      found_japanese = found_japanese or in_japanese
+      active_entry = nil
+      return
+    end
+
+    if not in_japanese then
+      active_entry = nil
+      return
+    end
+
+    if supported_parts_of_speech[text] then
+      active_entry = {
+        part_of_speech = text,
+        definitions = {},
+      }
+      table.insert(entries, active_entry)
+    else
+      active_entry = nil
+    end
+  end
+
+  local function finish_definition()
+    local definition = clean_text(definition_parts)
+    definition_parts = nil
+    if definition ~= "" then
+      table.insert(active_entry.definitions, definition)
+    end
+  end
+
+  for _, token in ipairs(tokens) do
+    if ignored_depth > 0 then
+      if token.kind == "start" and not token.self_closing then
+        ignored_depth = ignored_depth + 1
+      elseif token.kind == "end" then
+        ignored_depth = ignored_depth - 1
+      end
+    elseif token.kind == "start" and should_ignore(token) then
+      if not token.self_closing then
+        ignored_depth = 1
+      end
+    elseif token.kind == "start" then
+      local level = heading_level(token.name)
+      if level then
+        heading = { level = level, name = token.name, parts = {} }
+      elseif token.name == "ol" then
+        ordered_depth = ordered_depth + 1
+      elseif token.name == "li" then
+        list_item_depth = list_item_depth + 1
+        if active_entry and ordered_depth == 1 and list_item_depth == 1 then
+          definition_parts = {}
+        elseif definition_parts then
+          table.insert(definition_parts, " ")
+        end
+      elseif definition_parts and (token.name == "br" or token.name == "p") then
+        table.insert(definition_parts, " ")
+      end
+    elseif token.kind == "text" then
+      if heading then
+        table.insert(heading.parts, token.value)
+      elseif definition_parts then
+        table.insert(definition_parts, token.value)
+      end
+    elseif token.kind == "end" then
+      if heading and token.name == heading.name then
+        finish_heading()
+      elseif token.name == "li" then
+        if definition_parts and list_item_depth == 1 then
+          finish_definition()
+        end
+        list_item_depth = math.max(0, list_item_depth - 1)
+      elseif token.name == "ol" then
+        ordered_depth = math.max(0, ordered_depth - 1)
+      end
+    end
+  end
+
+  if not found_japanese then
+    return nil, { kind = "missing_japanese" }
+  end
+
+  local populated_entries = {}
+  for _, entry in ipairs(entries) do
+    if #entry.definitions > 0 then
+      table.insert(populated_entries, entry)
+    end
+  end
+
+  if #populated_entries == 0 then
+    return nil, { kind = "no_definitions" }
+  end
+
+  return populated_entries, nil
+end
+
+return M

--- a/dot_config/nvim/lua/wiktionary/parser.lua
+++ b/dot_config/nvim/lua/wiktionary/parser.lua
@@ -50,7 +50,7 @@ local function should_ignore(token)
 end
 
 local function clean_text(parts)
-  local text = table.concat(parts, " ")
+  local text = table.concat(parts, "")
   text = text:gsub("​", "")
   text = text:gsub("%s*%[%d+%]%s*", " ")
   text = text:gsub("%s+", " ")

--- a/dot_config/nvim/lua/wiktionary/ui.lua
+++ b/dot_config/nvim/lua/wiktionary/ui.lua
@@ -1,0 +1,68 @@
+local M = {}
+
+function M.format_result(result, options)
+  local lines = { result.query }
+  if result.page_title ~= result.query then
+    table.insert(lines, "ページ: " .. result.page_title)
+  end
+  table.insert(lines, "")
+
+  for entry_index, entry in ipairs(result.entries) do
+    if entry_index > 1 then
+      table.insert(lines, "")
+    end
+
+    table.insert(lines, entry.part_of_speech)
+    local visible_count = math.min(#entry.definitions, options.max_definitions)
+    for definition_index = 1, visible_count do
+      table.insert(lines, string.format("%d. %s", definition_index, entry.definitions[definition_index]))
+    end
+
+    local omitted_count = #entry.definitions - visible_count
+    if omitted_count > 0 then
+      table.insert(lines, string.format("…ほか%d件", omitted_count))
+    end
+  end
+
+  return lines
+end
+
+function M.show(result, options)
+  local bufnr, winid = vim.lsp.util.open_floating_preview(
+    M.format_result(result, options),
+    "plaintext",
+    {
+      border = options.border,
+      close_events = {},
+      focusable = true,
+      max_height = options.max_height,
+      max_width = options.max_width,
+      wrap = true,
+    }
+  )
+
+  local function close()
+    if vim.api.nvim_win_is_valid(winid) then
+      vim.api.nvim_win_close(winid, true)
+    end
+  end
+
+  vim.keymap.set("n", "q", close, { buffer = bufnr, nowait = true, silent = true })
+  vim.keymap.set("n", "<Esc>", close, { buffer = bufnr, nowait = true, silent = true })
+  vim.api.nvim_set_current_win(winid)
+
+  return bufnr, winid
+end
+
+function M.select(candidates, query, callback)
+  vim.ui.select(candidates, {
+    kind = "wiktionary",
+    prompt = "Wiktionaryの候補を選択: " .. query,
+  }, callback)
+end
+
+function M.notify(message, level)
+  vim.notify(message, level)
+end
+
+return M

--- a/dot_config/nvim/tests/minimal_init.lua
+++ b/dot_config/nvim/tests/minimal_init.lua
@@ -1,0 +1,5 @@
+local config_root = vim.fn.getcwd() .. "/dot_config/nvim"
+local plenary_root = vim.fn.stdpath("data") .. "/lazy/plenary.nvim"
+
+vim.opt.runtimepath:prepend(config_root)
+vim.opt.runtimepath:append(plenary_root)

--- a/dot_config/nvim/tests/wiktionary/api_spec.lua
+++ b/dot_config/nvim/tests/wiktionary/api_spec.lua
@@ -1,0 +1,182 @@
+local api = require("wiktionary.api")
+
+local function immediate_schedule(callback)
+  callback()
+end
+
+local function has_argument(arguments, expected)
+  for _, argument in ipairs(arguments) do
+    if argument == expected then
+      return true
+    end
+  end
+  return false
+end
+
+local function client_for(completed, captured)
+  return api.new({
+    executable = function()
+      return 1
+    end,
+    schedule = immediate_schedule,
+    system = function(arguments, options, on_exit)
+      captured.arguments = arguments
+      captured.options = options
+      on_exit(completed)
+      return {}
+    end,
+    user_agent = "nvim-wiktionary/test",
+  })
+end
+
+describe("wiktionary.api", function()
+  it("requests a parsed page asynchronously with curl data encoding", function()
+    local captured = {}
+    local client = client_for({
+      code = 0,
+      stderr = "",
+      stdout = vim.json.encode({
+        parse = {
+          redirects = { { from = "がいねん", to = "概念" } },
+          sections = { { line = "日本語" } },
+          text = "<h2>日本語</h2>",
+          title = "概念",
+        },
+        warnings = { parse = { warnings = "prop=sections is deprecated" } },
+      }),
+    }, captured)
+    local page
+
+    client.parse("がいねん", function(result, err)
+      assert.is_nil(err)
+      page = result
+    end)
+
+    assert.are.same({
+      html = "<h2>日本語</h2>",
+      sections = { { line = "日本語" } },
+      title = "概念",
+    }, page)
+    assert.are.equal(true, has_argument(captured.arguments, "--get"))
+    assert.are.equal(true, has_argument(captured.arguments, "--data-urlencode"))
+    assert.are.equal(true, has_argument(captured.arguments, "page=がいねん"))
+    assert.are.equal(true, has_argument(captured.arguments, "prop=text|sections"))
+    assert.are.equal(true, has_argument(captured.arguments, "redirects=1"))
+    assert.are.equal(true, has_argument(captured.arguments, "nvim-wiktionary/test"))
+    assert.are.same({ text = true }, captured.options)
+  end)
+
+  it("requests search candidates with the configured limit", function()
+    local captured = {}
+    local client = client_for({
+      code = 0,
+      stderr = "",
+      stdout = vim.json.encode({
+        query = {
+          search = {
+            { title = "概念" },
+            { title = "概念化" },
+          },
+        },
+      }),
+    }, captured)
+    local candidates
+
+    client.search("がいねん", 7, function(result, err)
+      assert.is_nil(err)
+      candidates = result
+    end)
+
+    assert.are.same({ "概念", "概念化" }, candidates)
+    assert.are.equal(true, has_argument(captured.arguments, "list=search"))
+    assert.are.equal(true, has_argument(captured.arguments, "srnamespace=0"))
+    assert.are.equal(true, has_argument(captured.arguments, "srlimit=7"))
+  end)
+
+  it("classifies MediaWiki and transport failures without exposing raw payloads", function()
+    local cases = {
+      {
+        completed = { code = 0, stdout = "not-json", stderr = "" },
+        expected = "json",
+      },
+      {
+        completed = {
+          code = 0,
+          stdout = vim.json.encode({ error = { code = "missingtitle", info = "raw" } }),
+          stderr = "",
+        },
+        expected = "not_found",
+      },
+      {
+        completed = {
+          code = 0,
+          stdout = vim.json.encode({ error = { code = "internal_api_error", info = "raw" } }),
+          stderr = "",
+        },
+        expected = "api",
+      },
+      {
+        completed = { code = 22, stdout = "", stderr = "HTTP raw" },
+        expected = "api",
+      },
+      {
+        completed = { code = 6, stdout = "", stderr = "DNS raw" },
+        expected = "network",
+      },
+    }
+
+    for _, case in ipairs(cases) do
+      local client = client_for(case.completed, {})
+      local received_error
+
+      client.parse("概念", function(_, err)
+        received_error = err
+      end)
+
+      assert.are.equal(case.expected, received_error.kind)
+      assert.is_nil(received_error.raw)
+    end
+  end)
+
+  it("distinguishes a missing curl executable", function()
+    local system_called = false
+    local client = api.new({
+      executable = function()
+        return 0
+      end,
+      schedule = immediate_schedule,
+      system = function()
+        system_called = true
+      end,
+      user_agent = "nvim-wiktionary/test",
+    })
+    local received_error
+
+    client.parse("概念", function(_, err)
+      received_error = err
+    end)
+
+    assert.are.equal("curl_missing", received_error.kind)
+    assert.is_false(system_called)
+  end)
+
+  it("classifies a process start exception as a network failure", function()
+    local client = api.new({
+      executable = function()
+        return 1
+      end,
+      schedule = immediate_schedule,
+      system = function()
+        error("spawn failure")
+      end,
+      user_agent = "nvim-wiktionary/test",
+    })
+    local received_error
+
+    client.parse("概念", function(_, err)
+      received_error = err
+    end)
+
+    assert.are.equal("network", received_error.kind)
+  end)
+end)

--- a/dot_config/nvim/tests/wiktionary/api_spec.lua
+++ b/dot_config/nvim/tests/wiktionary/api_spec.lua
@@ -93,6 +93,28 @@ describe("wiktionary.api", function()
     assert.are.equal(true, has_argument(captured.arguments, "srlimit=7"))
   end)
 
+  it("classifies malformed search items as API failures", function()
+    local kinds = {}
+
+    for _, item in ipairs({ false, { title = 7 } }) do
+      local client = client_for({
+        code = 0,
+        stderr = "",
+        stdout = vim.json.encode({
+          query = {
+            search = { item },
+          },
+        }),
+      }, {})
+
+      client.search("概念", 7, function(_, err)
+        table.insert(kinds, err and err.kind or "success")
+      end)
+    end
+
+    assert.are.same({ "api", "api" }, kinds)
+  end)
+
   it("classifies MediaWiki and transport failures without exposing raw payloads", function()
     local cases = {
       {
@@ -158,6 +180,45 @@ describe("wiktionary.api", function()
 
     assert.are.equal("curl_missing", received_error.kind)
     assert.is_false(system_called)
+  end)
+
+  it("keeps a completed result when system throws after exit", function()
+    local calls = {}
+    local client = api.new({
+      executable = function()
+        return 1
+      end,
+      schedule = immediate_schedule,
+      system = function(_, _, on_exit)
+        on_exit({
+          code = 0,
+          stderr = "",
+          stdout = vim.json.encode({
+            parse = {
+              sections = {},
+              text = "<h2>日本語</h2>",
+              title = "概念",
+            },
+          }),
+        })
+        error("failure after exit")
+      end,
+      user_agent = "nvim-wiktionary/test",
+    })
+
+    client.parse("概念", function(result, err)
+      table.insert(calls, { err = err, result = result })
+    end)
+
+    assert.are.same({
+      {
+        result = {
+          html = "<h2>日本語</h2>",
+          sections = {},
+          title = "概念",
+        },
+      },
+    }, calls)
   end)
 
   it("classifies a process start exception as a network failure", function()

--- a/dot_config/nvim/tests/wiktionary/api_spec.lua
+++ b/dot_config/nvim/tests/wiktionary/api_spec.lua
@@ -13,6 +13,15 @@ local function has_argument(arguments, expected)
   return false
 end
 
+local function has_argument_pair(arguments, expected, value)
+  for index, argument in ipairs(arguments) do
+    if argument == expected and arguments[index + 1] == value then
+      return true
+    end
+  end
+  return false
+end
+
 local function client_for(completed, captured)
   return api.new({
     executable = function()
@@ -63,6 +72,7 @@ describe("wiktionary.api", function()
     assert.are.equal(true, has_argument(captured.arguments, "prop=text|sections"))
     assert.are.equal(true, has_argument(captured.arguments, "redirects=1"))
     assert.are.equal(true, has_argument(captured.arguments, "nvim-wiktionary/test"))
+    assert.are.equal(true, has_argument_pair(captured.arguments, "--max-time", "10"))
     assert.are.same({ text = true }, captured.options)
   end)
 

--- a/dot_config/nvim/tests/wiktionary/command_spec.lua
+++ b/dot_config/nvim/tests/wiktionary/command_spec.lua
@@ -1,0 +1,39 @@
+describe(":Wiktionary", function()
+  local calls
+
+  before_each(function()
+    calls = { normal = 0, visual = 0 }
+    package.loaded["wiktionary"] = {
+      lookup = function()
+        calls.normal = calls.normal + 1
+      end,
+      lookup_visual = function()
+        calls.visual = calls.visual + 1
+      end,
+    }
+    pcall(vim.api.nvim_del_user_command, "Wiktionary")
+    dofile(vim.fn.getcwd() .. "/dot_config/nvim/lua/config/commands/wiktionary.lua")
+  end)
+
+  after_each(function()
+    pcall(vim.api.nvim_del_user_command, "Wiktionary")
+    package.loaded["wiktionary"] = nil
+  end)
+
+  it("routes a command without a range to lookup", function()
+    vim.cmd("Wiktionary")
+
+    assert.are.same({ normal = 1, visual = 0 }, calls)
+  end)
+
+  it("routes an explicit range to lookup_visual", function()
+    vim.cmd("1,1Wiktionary")
+
+    assert.are.same({ normal = 0, visual = 1 }, calls)
+  end)
+
+  it("does not define fixed normal or visual mappings", function()
+    assert.are.same({}, vim.fn.maparg("<leader>d", "n", false, true))
+    assert.are.same({}, vim.fn.maparg("<leader>d", "x", false, true))
+  end)
+end)

--- a/dot_config/nvim/tests/wiktionary/command_spec.lua
+++ b/dot_config/nvim/tests/wiktionary/command_spec.lua
@@ -2,6 +2,7 @@ describe(":Wiktionary", function()
   local calls
 
   before_each(function()
+    vim.cmd("enew!")
     calls = { normal = 0, visual = {} }
     package.loaded["wiktionary"] = {
       lookup = function()
@@ -30,6 +31,15 @@ describe(":Wiktionary", function()
     vim.cmd("1,1Wiktionary")
 
     assert.are.same({ normal = 0, visual = { { 1, 1 } } }, calls)
+  end)
+
+  it("preserves the active visual selection", function()
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, { "日本語辞書" })
+    local keys = vim.api.nvim_replace_termcodes("gg0vll:Wiktionary<CR>", true, false, true)
+
+    vim.api.nvim_feedkeys(keys, "xt", false)
+
+    assert.are.same({ normal = 0, visual = { {} } }, calls)
   end)
 
   it("does not define fixed normal or visual mappings", function()

--- a/dot_config/nvim/tests/wiktionary/command_spec.lua
+++ b/dot_config/nvim/tests/wiktionary/command_spec.lua
@@ -2,13 +2,13 @@ describe(":Wiktionary", function()
   local calls
 
   before_each(function()
-    calls = { normal = 0, visual = 0 }
+    calls = { normal = 0, visual = {} }
     package.loaded["wiktionary"] = {
       lookup = function()
         calls.normal = calls.normal + 1
       end,
-      lookup_visual = function()
-        calls.visual = calls.visual + 1
+      lookup_visual = function(line1, line2)
+        table.insert(calls.visual, { line1, line2 })
       end,
     }
     pcall(vim.api.nvim_del_user_command, "Wiktionary")
@@ -23,13 +23,13 @@ describe(":Wiktionary", function()
   it("routes a command without a range to lookup", function()
     vim.cmd("Wiktionary")
 
-    assert.are.same({ normal = 1, visual = 0 }, calls)
+    assert.are.same({ normal = 1, visual = {} }, calls)
   end)
 
   it("routes an explicit range to lookup_visual", function()
     vim.cmd("1,1Wiktionary")
 
-    assert.are.same({ normal = 0, visual = 1 }, calls)
+    assert.are.same({ normal = 0, visual = { { 1, 1 } } }, calls)
   end)
 
   it("does not define fixed normal or visual mappings", function()

--- a/dot_config/nvim/tests/wiktionary/core_spec.lua
+++ b/dot_config/nvim/tests/wiktionary/core_spec.lua
@@ -1,0 +1,242 @@
+local core = require("wiktionary.core")
+
+local default_config = {
+  border = "rounded",
+  cache = true,
+  max_definitions = 5,
+  max_height = 30,
+  max_width = 80,
+  search_limit = 10,
+}
+
+local definitions = {
+  {
+    definitions = { "物事の意味内容。" },
+    part_of_speech = "名詞",
+  },
+}
+
+local function new_ui(choice)
+  local state = {
+    notifications = {},
+    selections = {},
+    shown = {},
+  }
+
+  return {
+    notify = function(message, level)
+      table.insert(state.notifications, { level = level, message = message })
+    end,
+    select = function(candidates, query, callback)
+      table.insert(state.selections, { candidates = candidates, query = query })
+      callback(choice == false and nil or choice or candidates[1])
+    end,
+    show = function(result, config)
+      table.insert(state.shown, { config = config, result = result })
+    end,
+  }, state
+end
+
+local function successful_parser()
+  return {
+    extract = function()
+      return definitions, nil
+    end,
+  }
+end
+
+describe("wiktionary.core", function()
+  it("normalizes the query and reuses a session cache entry", function()
+    local parse_calls = 0
+    local client = {
+      parse = function(title, callback)
+        parse_calls = parse_calls + 1
+        callback({ html = "html", sections = {}, title = title }, nil)
+      end,
+      search = function()
+        error("search must not run for an exact page")
+      end,
+    }
+    local ui, state = new_ui()
+    local engine = core.new({
+      client = client,
+      config = default_config,
+      now = function()
+        return 123
+      end,
+      parser = successful_parser(),
+      ui = ui,
+    })
+
+    engine.lookup("  概念\n")
+    engine.lookup("概念")
+
+    assert.are.equal(1, parse_calls)
+    assert.are.equal(2, #state.shown)
+    assert.are.equal("概念", state.shown[1].result.query)
+    assert.are.equal("概念", state.shown[1].result.page_title)
+    assert.are.equal(123, state.shown[1].result.fetched_at)
+    assert.are.same(definitions, state.shown[1].result.entries)
+  end)
+
+  it("bypasses the cache when cache is disabled", function()
+    local parse_calls = 0
+    local config = vim.tbl_extend("force", default_config, { cache = false })
+    local client = {
+      parse = function(title, callback)
+        parse_calls = parse_calls + 1
+        callback({ html = "html", sections = {}, title = title }, nil)
+      end,
+      search = function()
+        error("search must not run")
+      end,
+    }
+    local ui = new_ui()
+    local engine = core.new({ client = client, config = config, parser = successful_parser(), ui = ui })
+
+    engine.lookup("概念")
+    engine.lookup("概念")
+
+    assert.are.equal(2, parse_calls)
+  end)
+
+  it("searches only after a missing exact page and caches the chosen page under the original query", function()
+    local parsed_titles = {}
+    local search_calls = 0
+    local client = {
+      parse = function(title, callback)
+        table.insert(parsed_titles, title)
+        if title == "がいねん" then
+          callback(nil, { kind = "not_found" })
+        else
+          callback({ html = "html", sections = {}, title = "概念" }, nil)
+        end
+      end,
+      search = function(term, limit, callback)
+        search_calls = search_calls + 1
+        assert.are.equal("がいねん", term)
+        assert.are.equal(10, limit)
+        callback({ "概念", "概念化" }, nil)
+      end,
+    }
+    local ui, state = new_ui("概念")
+    local engine = core.new({ client = client, config = default_config, parser = successful_parser(), ui = ui })
+
+    engine.lookup("がいねん")
+    engine.lookup("がいねん")
+
+    assert.are.same({ "がいねん", "概念" }, parsed_titles)
+    assert.are.equal(1, search_calls)
+    assert.are.equal(1, #state.selections)
+    assert.are.equal("がいねん", state.shown[1].result.query)
+    assert.are.equal("概念", state.shown[1].result.page_title)
+    assert.are.equal(2, #state.shown)
+  end)
+
+  it("does not start a second request while the same query is pending", function()
+    local parse_calls = 0
+    local pending_callback
+    local client = {
+      parse = function(_, callback)
+        parse_calls = parse_calls + 1
+        pending_callback = callback
+      end,
+      search = function()
+        error("search must not run")
+      end,
+    }
+    local ui, state = new_ui()
+    local engine = core.new({ client = client, config = default_config, parser = successful_parser(), ui = ui })
+
+    engine.lookup("概念")
+    engine.lookup("概念")
+    assert.are.equal(1, parse_calls)
+
+    pending_callback({ html = "html", sections = {}, title = "概念" }, nil)
+    assert.are.equal(1, #state.shown)
+  end)
+
+  it("notifies when search returns no candidates", function()
+    local client = {
+      parse = function(_, callback)
+        callback(nil, { kind = "not_found" })
+      end,
+      search = function(_, _, callback)
+        callback({}, nil)
+      end,
+    }
+    local ui, state = new_ui()
+    local engine = core.new({ client = client, config = default_config, parser = successful_parser(), ui = ui })
+
+    engine.lookup("未登録語")
+
+    assert.are.equal('Wiktionaryに「未登録語」のページが見つかりませんでした。', state.notifications[1].message)
+    assert.are.equal(vim.log.levels.ERROR, state.notifications[1].level)
+  end)
+
+  it("maps API failures to stable user-facing messages", function()
+    local cases = {
+      { kind = "curl_missing", message = "curlが見つかりません。" },
+      { kind = "network", message = "Wiktionaryへの接続に失敗しました。" },
+      { kind = "api", message = "Wiktionary APIでエラーが発生しました。" },
+      { kind = "json", message = "Wiktionary APIの応答を解析できませんでした。" },
+    }
+
+    for _, case in ipairs(cases) do
+      local client = {
+        parse = function(_, callback)
+          callback(nil, { kind = case.kind })
+        end,
+        search = function()
+          error("search must not run")
+        end,
+      }
+      local ui, state = new_ui()
+      local engine = core.new({ client = client, config = default_config, parser = successful_parser(), ui = ui })
+
+      engine.lookup("概念")
+
+      assert.are.equal(case.message, state.notifications[1].message)
+      assert.is_nil(state.notifications[1].raw)
+    end
+  end)
+
+  it("distinguishes Japanese-section, definition, and HTML extraction failures", function()
+    local cases = {
+      {
+        kind = "missing_japanese",
+        message = 'Wiktionaryの「概念」ページに日本語セクションがありません。',
+      },
+      {
+        kind = "no_definitions",
+        message = "語義を抽出できませんでした。\nhttps://ja.wiktionary.org/wiki/%e6%a6%82%e5%bf%b5",
+      },
+      {
+        kind = "html_parse",
+        message = "WiktionaryのHTMLを解析できませんでした。\nhttps://ja.wiktionary.org/wiki/%e6%a6%82%e5%bf%b5",
+      },
+    }
+
+    for _, case in ipairs(cases) do
+      local client = {
+        parse = function(_, callback)
+          callback({ html = "html", sections = {}, title = "概念" }, nil)
+        end,
+        search = function()
+          error("search must not run")
+        end,
+      }
+      local parser = {
+        extract = function()
+          return nil, { kind = case.kind }
+        end,
+      }
+      local ui, state = new_ui()
+      local engine = core.new({ client = client, config = default_config, parser = parser, ui = ui })
+
+      engine.lookup("概念")
+
+      assert.are.equal(case.message, state.notifications[1].message)
+    end
+  end)
+end)

--- a/dot_config/nvim/tests/wiktionary/core_spec.lua
+++ b/dot_config/nvim/tests/wiktionary/core_spec.lua
@@ -79,6 +79,48 @@ describe("wiktionary.core", function()
     assert.are.same(definitions, state.shown[1].result.entries)
   end)
 
+  it("suppresses a reentrant lookup until the first lookup finishes", function()
+    local engine
+    local parse_calls = 0
+    local reentered = false
+    local show_calls = 0
+    local client = {
+      parse = function(title, callback)
+        parse_calls = parse_calls + 1
+        callback({ html = "html", sections = {}, title = title }, nil)
+      end,
+      search = function()
+        error("search must not run")
+      end,
+    }
+    local ui = {
+      notify = function()
+        error("notify must not run")
+      end,
+      select = function()
+        error("select must not run")
+      end,
+      show = function()
+        show_calls = show_calls + 1
+        if not reentered then
+          reentered = true
+          engine.lookup("概念")
+        end
+      end,
+    }
+    engine = core.new({ client = client, config = default_config, parser = successful_parser(), ui = ui })
+
+    engine.lookup("概念")
+
+    assert.are.equal(1, parse_calls)
+    assert.are.equal(1, show_calls)
+
+    engine.lookup("概念")
+
+    assert.are.equal(1, parse_calls)
+    assert.are.equal(2, show_calls)
+  end)
+
   it("bypasses the cache when cache is disabled", function()
     local parse_calls = 0
     local config = vim.tbl_extend("force", default_config, { cache = false })

--- a/dot_config/nvim/tests/wiktionary/html_spec.lua
+++ b/dot_config/nvim/tests/wiktionary/html_spec.lua
@@ -1,0 +1,46 @@
+local html = require("wiktionary.html")
+
+describe("wiktionary.html", function()
+  it("tokenizes tags without treating a quoted angle bracket as the tag end", function()
+    local tokens, reason = html.tokenize([[
+      <!-- ignored -->
+      <div class="definition primary" data-label="1 > 0">A&amp;B<br>C&#x65E5;</div>
+    ]])
+
+    assert.is_nil(reason)
+    assert.are.same({
+      { kind = "text", value = "      " },
+      { kind = "text", value = "\n      " },
+      {
+        class = "definition primary",
+        kind = "start",
+        name = "div",
+        self_closing = false,
+      },
+      { kind = "text", value = "A&B" },
+      {
+        class = nil,
+        kind = "start",
+        name = "br",
+        self_closing = true,
+      },
+      { kind = "text", value = "C日" },
+      { kind = "end", name = "div" },
+      { kind = "text", value = "\n    " },
+    }, tokens)
+  end)
+
+  it("reports an unterminated tag", function()
+    local tokens, reason = html.tokenize("<div")
+
+    assert.is_nil(tokens)
+    assert.are.equal("unterminated_tag", reason)
+  end)
+
+  it("reports an unterminated comment", function()
+    local tokens, reason = html.tokenize("<!-- broken")
+
+    assert.is_nil(tokens)
+    assert.are.equal("unterminated_comment", reason)
+  end)
+end)

--- a/dot_config/nvim/tests/wiktionary/html_spec.lua
+++ b/dot_config/nvim/tests/wiktionary/html_spec.lua
@@ -30,6 +30,13 @@ describe("wiktionary.html", function()
     }, tokens)
   end)
 
+  it("does not treat class text inside other attributes as a class attribute", function()
+    local tokens, reason = html.tokenize([[<div data-class="reference" data-label='class="fake"'>x</div>]])
+
+    assert.is_nil(reason)
+    assert.is_nil(tokens[1].class)
+  end)
+
   it("reports an unterminated tag", function()
     local tokens, reason = html.tokenize("<div")
 

--- a/dot_config/nvim/tests/wiktionary/init_spec.lua
+++ b/dot_config/nvim/tests/wiktionary/init_spec.lua
@@ -1,0 +1,79 @@
+describe("wiktionary public facade", function()
+  local captured
+
+  local function load_wiktionary()
+    package.loaded["wiktionary"] = nil
+    package.loaded["wiktionary.api"] = {
+      new = function(options)
+        captured.api_options = options
+        return { parse = function() end, search = function() end }
+      end,
+    }
+    package.loaded["wiktionary.core"] = {
+      new = function(dependencies)
+        captured.config = vim.deepcopy(dependencies.config)
+        return {
+          lookup = function(query)
+            table.insert(captured.queries, query)
+          end,
+        }
+      end,
+    }
+    package.loaded["wiktionary.parser"] = { extract = function() end }
+    package.loaded["wiktionary.ui"] = { notify = function() end }
+    return require("wiktionary")
+  end
+
+  before_each(function()
+    captured = { queries = {} }
+    vim.cmd("enew!")
+  end)
+
+  after_each(function()
+    vim.cmd("normal! \27")
+    package.loaded["wiktionary"] = nil
+    package.loaded["wiktionary.api"] = nil
+    package.loaded["wiktionary.core"] = nil
+    package.loaded["wiktionary.parser"] = nil
+    package.loaded["wiktionary.ui"] = nil
+  end)
+
+  it("merges setup options and looks up kanji, hiragana, and katakana cwords", function()
+    local wiktionary = load_wiktionary()
+    wiktionary.setup({
+      cache = false,
+      max_definitions = 3,
+      search_limit = 7,
+      user_agent = "nvim-wiktionary/custom",
+    })
+    local line = "概念 ひらがな カタカナ"
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, { line })
+    for _, term in ipairs({ "概念", "ひらがな", "カタカナ" }) do
+      local byte_index = assert(line:find(term, 1, true))
+      vim.api.nvim_win_set_cursor(0, { 1, byte_index - 1 })
+      wiktionary.lookup()
+    end
+
+    assert.are.same({ "概念", "ひらがな", "カタカナ" }, captured.queries)
+    assert.are.equal("nvim-wiktionary/custom", captured.api_options.user_agent)
+    assert.are.equal(false, captured.config.cache)
+    assert.are.equal(3, captured.config.max_definitions)
+    assert.are.equal(7, captured.config.search_limit)
+    assert.are.equal(80, captured.config.max_width)
+    assert.are.equal(30, captured.config.max_height)
+    assert.are.equal("rounded", captured.config.border)
+  end)
+
+  it("looks up the active visual selection", function()
+    local wiktionary = load_wiktionary()
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, { "日本語辞書" })
+    vim.cmd("normal! gg0vll")
+
+    wiktionary.lookup_visual()
+
+    assert.are.same({ "日本語" }, captured.queries)
+    assert.are.equal("nvim-wiktionary/0.1", captured.api_options.user_agent)
+    assert.are.equal(true, captured.config.cache)
+    assert.are.equal(10, captured.config.search_limit)
+  end)
+end)

--- a/dot_config/nvim/tests/wiktionary/init_spec.lua
+++ b/dot_config/nvim/tests/wiktionary/init_spec.lua
@@ -76,4 +76,13 @@ describe("wiktionary public facade", function()
     assert.are.equal(true, captured.config.cache)
     assert.are.equal(10, captured.config.search_limit)
   end)
+
+  it("looks up the specified line range", function()
+    local wiktionary = load_wiktionary()
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, { " 日本語 ", "", " 辞書 " })
+
+    wiktionary.lookup_visual(1, 3)
+
+    assert.are.same({ "日本語 辞書" }, captured.queries)
+  end)
 end)

--- a/dot_config/nvim/tests/wiktionary/parser_spec.lua
+++ b/dot_config/nvim/tests/wiktionary/parser_spec.lua
@@ -1,0 +1,75 @@
+local parser = require("wiktionary.parser")
+
+local representative_html = [[
+<div class="mw-parser-output">
+  <div class="mw-heading mw-heading2">
+    <h2 id="日本語">日本語</h2>
+    <span class="mw-editsection">[編集]</span>
+  </div>
+  <div class="mw-heading mw-heading3"><h3 id="語源">語源</h3></div>
+  <ol><li>語源の番号付き項目は除外する。</li></ol>
+  <div class="mw-heading mw-heading3"><h3 id="名詞">名詞</h3></div>
+  <p>見出し語の説明</p>
+  <ol>
+    <li><a href="/wiki/第一">第一の意味</a> &amp; 補足<sup class="reference">[1]</sup><ul><li>短い用例</li></ul><table><tr><td>大きな表</td></tr></table><blockquote>長い引用</blockquote></li>
+    <li>第二の意味</li>
+    <li>第三の意味</li>
+    <li>第四の意味</li>
+    <li>第五の意味</li>
+    <li>第六の意味</li>
+  </ol>
+  <div class="mw-heading mw-heading4"><h4 id="関連語">関連語</h4></div>
+  <ol><li>関連語の番号付き項目は除外する。</li></ol>
+  <div class="mw-heading mw-heading3"><h3 id="動詞">動詞</h3></div>
+  <ol><li><span>動作を表す。</span></li></ol>
+  <div class="mw-heading mw-heading2"><h2 id="中国語">中国語</h2></div>
+  <div class="mw-heading mw-heading3"><h3 id="名詞_2">名詞</h3></div>
+  <ol><li>外国語の意味は除外する。</li></ol>
+</div>
+]]
+
+describe("wiktionary.parser", function()
+  it("extracts only definitions under supported parts of speech in the Japanese section", function()
+    local entries, err = parser.extract(representative_html)
+
+    assert.is_nil(err)
+    assert.are.same({
+      {
+        part_of_speech = "名詞",
+        definitions = {
+          "第一の意味 & 補足 短い用例",
+          "第二の意味",
+          "第三の意味",
+          "第四の意味",
+          "第五の意味",
+          "第六の意味",
+        },
+      },
+      {
+        part_of_speech = "動詞",
+        definitions = { "動作を表す。" },
+      },
+    }, entries)
+  end)
+
+  it("distinguishes a missing Japanese section", function()
+    local entries, err = parser.extract("<h2>中国語</h2><h3>名詞</h3><ol><li>意味</li></ol>")
+
+    assert.is_nil(entries)
+    assert.are.equal("missing_japanese", err.kind)
+  end)
+
+  it("distinguishes a Japanese section without supported definitions", function()
+    local entries, err = parser.extract("<h2>日本語</h2><h3>語源</h3><p>説明</p>")
+
+    assert.is_nil(entries)
+    assert.are.equal("no_definitions", err.kind)
+  end)
+
+  it("distinguishes malformed HTML", function()
+    local entries, err = parser.extract("<div")
+
+    assert.is_nil(entries)
+    assert.are.equal("html_parse", err.kind)
+  end)
+end)

--- a/dot_config/nvim/tests/wiktionary/parser_spec.lua
+++ b/dot_config/nvim/tests/wiktionary/parser_spec.lua
@@ -52,6 +52,22 @@ describe("wiktionary.parser", function()
     }, entries)
   end)
 
+  it("preserves Japanese text across inline links", function()
+    local entries, err = parser.extract([[
+      <h2>日本語</h2>
+      <h3>名詞</h3>
+      <ol><li>ものの<a href="/wiki/姿">姿</a>を、ある<a href="/wiki/平面">平面</a>に映すこと。</li></ol>
+    ]])
+
+    assert.is_nil(err)
+    assert.are.same({
+      {
+        part_of_speech = "名詞",
+        definitions = { "ものの姿を、ある平面に映すこと。" },
+      },
+    }, entries)
+  end)
+
   it("distinguishes a missing Japanese section", function()
     local entries, err = parser.extract("<h2>中国語</h2><h3>名詞</h3><ol><li>意味</li></ol>")
 

--- a/dot_config/nvim/tests/wiktionary/ui_spec.lua
+++ b/dot_config/nvim/tests/wiktionary/ui_spec.lua
@@ -1,0 +1,101 @@
+local ui = require("wiktionary.ui")
+
+local result = {
+  entries = {
+    {
+      part_of_speech = "名詞",
+      definitions = {
+        "第一の意味",
+        "第二の意味",
+        "第三の意味",
+        "第四の意味",
+        "第五の意味",
+        "第六の意味",
+      },
+    },
+    {
+      part_of_speech = "動詞",
+      definitions = { "動作を表す" },
+    },
+  },
+  fetched_at = 1,
+  page_title = "概念",
+  query = "がいねん",
+}
+
+describe("wiktionary.ui", function()
+  local original_select
+
+  before_each(function()
+    original_select = vim.ui.select
+    vim.cmd("enew!")
+  end)
+
+  after_each(function()
+    vim.ui.select = original_select
+    for _, winid in ipairs(vim.api.nvim_list_wins()) do
+      if vim.api.nvim_win_get_config(winid).relative ~= "" then
+        vim.api.nvim_win_close(winid, true)
+      end
+    end
+  end)
+
+  it("formats the query, resolved page, numbered definitions, and omitted count", function()
+    assert.are.same({
+      "がいねん",
+      "ページ: 概念",
+      "",
+      "名詞",
+      "1. 第一の意味",
+      "2. 第二の意味",
+      "3. 第三の意味",
+      "4. 第四の意味",
+      "5. 第五の意味",
+      "…ほか1件",
+      "",
+      "動詞",
+      "1. 動作を表す",
+    }, ui.format_result(result, { max_definitions = 5 }))
+  end)
+
+  it("opens a focused bounded floating window with close mappings", function()
+    local bufnr, winid = ui.show(result, {
+      border = "rounded",
+      max_definitions = 5,
+      max_height = 4,
+      max_width = 24,
+    })
+
+    assert.is_true(vim.api.nvim_buf_is_valid(bufnr))
+    assert.is_true(vim.api.nvim_win_is_valid(winid))
+    assert.are.equal(winid, vim.api.nvim_get_current_win())
+    assert.is_true(vim.api.nvim_win_get_width(winid) <= 24)
+    assert.is_true(vim.api.nvim_win_get_height(winid) <= 4)
+
+    local lhs = {}
+    for _, mapping in ipairs(vim.api.nvim_buf_get_keymap(bufnr, "n")) do
+      lhs[mapping.lhs] = true
+    end
+    assert.is_true(lhs.q)
+    assert.is_true(lhs["<Esc>"])
+  end)
+
+  it("delegates candidates to vim.ui.select", function()
+    local captured = {}
+    vim.ui.select = function(items, options, on_choice)
+      captured.items = items
+      captured.options = options
+      on_choice(items[2])
+    end
+    local selected
+
+    ui.select({ "概念", "概念化" }, "がいねん", function(choice)
+      selected = choice
+    end)
+
+    assert.are.same({ "概念", "概念化" }, captured.items)
+    assert.are.equal("Wiktionaryの候補を選択: がいねん", captured.options.prompt)
+    assert.are.equal("wiktionary", captured.options.kind)
+    assert.are.equal("概念化", selected)
+  end)
+end)

--- a/dot_config/nvim/tests/wiktionary/utils_spec.lua
+++ b/dot_config/nvim/tests/wiktionary/utils_spec.lua
@@ -1,0 +1,28 @@
+local utils = require("config.utils")
+
+describe("config.utils visual query", function()
+  before_each(function()
+    vim.cmd("enew!")
+  end)
+
+  after_each(function()
+    vim.cmd("normal! \27")
+  end)
+
+  it("reads the active multibyte visual selection", function()
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, { "日本語辞書" })
+    vim.cmd("normal! gg0vll")
+
+    assert.are.equal("日本語", utils.get_visual_query_text())
+  end)
+
+  it("normalizes the last multiline visual selection", function()
+    vim.api.nvim_buf_set_lines(0, 0, -1, false, { "  日本語", "辞書  " })
+    vim.cmd("normal! ggVj")
+    vim.cmd("normal! \27")
+    vim.fn.setpos("'<", { 0, 1, 1, 0 })
+    vim.fn.setpos("'>", { 0, 2, 1, 0 })
+
+    assert.are.equal("日本語 辞書", utils.get_visual_query_text())
+  end)
+end)


### PR DESCRIPTION
## Why

Neovimから離れずに、カーソル位置またはビジュアル選択した日本語の語義を日本語版Wiktionaryで確認できるようにします。

## Changes

- :WiktionaryコマンドとLua APIを追加
- vim.system()とcurlを使った非同期MediaWiki APIクライアントを追加
- 日本語セクションから品詞別の語義だけを抽出するHTMLパーサーを追加
- 検索候補の選択、セッションキャッシュ、安定したエラー通知を追加
- 結果を閉じたりスクロールしたりできるフローティングウィンドウで表示
- カーソル語句と複数行を含むビジュアル選択の取得に対応
- インラインリンクで分割された日本語に不要な空白が入らないよう調整
- 固定のグローバルキーマッピングや追加Lua依存は導入しない

## Related Issues

None.

## Test Cases

- カーソル語句とビジュアル選択から検索語を取得できる
- API成功、検索候補、通信失敗、APIエラー、JSON不正を処理できる
- 日本語セクションと対応品詞の語義だけを抽出できる
- インラインリンク前後の日本語を自然な間隔で連結できる
- フローティングウィンドウの表示、件数制限、終了操作を確認
- Wiktionaryテスト全34件が成功